### PR TITLE
アプリを英語、日本語、韓国語、中国語に対応

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -31,6 +31,8 @@ PODS:
   - FirebaseCoreInternal (11.10.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
   - Flutter (1.0.0)
+  - flutter_localization (0.0.1):
+    - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
   - fluttertoast (0.0.2):
@@ -74,6 +76,7 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
+  - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
@@ -101,6 +104,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
+  flutter_localization:
+    :path: ".symlinks/plugins/flutter_localization/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   fluttertoast:
@@ -125,6 +130,7 @@ SPEC CHECKSUMS:
   FirebaseCoreExtension: 6f357679327f3614e995dc7cf3f2d600bdc774ac
   FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_localization: f43b18844a2b3d2c71fd64f04ffd6b1e64dd54d4
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -31,8 +31,6 @@ PODS:
   - FirebaseCoreInternal (11.10.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
   - Flutter (1.0.0)
-  - flutter_localization (0.0.1):
-    - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
   - fluttertoast (0.0.2):
@@ -76,7 +74,6 @@ DEPENDENCIES:
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
-  - flutter_localization (from `.symlinks/plugins/flutter_localization/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
@@ -104,8 +101,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_core/ios"
   Flutter:
     :path: Flutter
-  flutter_localization:
-    :path: ".symlinks/plugins/flutter_localization/ios"
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   fluttertoast:
@@ -130,7 +125,6 @@ SPEC CHECKSUMS:
   FirebaseCoreExtension: 6f357679327f3614e995dc7cf3f2d600bdc774ac
   FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_localization: f43b18844a2b3d2c71fd64f04ffd6b1e64dd54d4
   flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
   fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,8 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+preferred-supported-locales:
+  - en
+  - ja
+  - zh
+  - ko

--- a/lib/common_widget/dialog/confirm_dialog.dart
+++ b/lib/common_widget/dialog/confirm_dialog.dart
@@ -4,6 +4,7 @@ import 'package:search_repositories/common_widget/custom_button.dart';
 import 'package:search_repositories/config/util/custom_font_size.dart';
 import 'package:search_repositories/config/util/height_margin.dart';
 import 'package:search_repositories/config/util/width_margin.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void showConfirmDialog({
   required BuildContext context,
@@ -26,11 +27,18 @@ class ConfirmDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+
+    // null対策
+    final String confirmTitle = localizations?.confirmTitle ?? '確認';
+    final String yesText = localizations?.yes ?? 'はい';
+    final String noText = localizations?.no ?? 'いいえ';
+
     return AlertDialog(
-      title: const Text(
-        '確認',
+      title: Text(
+        confirmTitle,
         textAlign: TextAlign.center,
-        style: TextStyle(
+        style: const TextStyle(
           fontSize: CustomFontSize.large,
           fontWeight: FontWeight.bold,
         ),
@@ -55,7 +63,7 @@ class ConfirmDialog extends StatelessWidget {
                 onPressed: () {
                   context.pop();
                 },
-                text: 'いいえ',
+                text: noText,
                 isColorReversed: true,
               ),
             ),
@@ -65,7 +73,7 @@ class ConfirmDialog extends StatelessWidget {
                 onPressed: () {
                   onPressed();
                 },
-                text: 'はい',
+                text: yesText,
               ),
             ),
           ],

--- a/lib/config/locale/controller/locale_provider.dart
+++ b/lib/config/locale/controller/locale_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'locale_provider.g.dart';
+
+@riverpod
+class LocaleNotifier extends _$LocaleNotifier {
+  static const String _kLanguageCode = 'languageCode';
+  static const String _kScriptCode = 'scriptCode';
+  static const String _kCountryCode = 'countryCode';
+
+  @override
+  Locale build() {
+    _loadLocale();
+    return const Locale('ja');
+  }
+
+  Future<void> _loadLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final languageCode = prefs.getString(_kLanguageCode);
+    final scriptCode = prefs.getString(_kScriptCode);
+    final countryCode = prefs.getString(_kCountryCode);
+
+    if (languageCode != null) {
+      state = Locale.fromSubtags(
+        languageCode: languageCode,
+        scriptCode: scriptCode,
+        countryCode: countryCode,
+      );
+    }
+  }
+
+  Future<void> setLocale(Locale locale) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_kLanguageCode, locale.languageCode);
+
+    if (locale.scriptCode != null) {
+      await prefs.setString(_kScriptCode, locale.scriptCode!);
+    } else {
+      await prefs.remove(_kScriptCode);
+    }
+
+    if (locale.countryCode != null) {
+      await prefs.setString(_kCountryCode, locale.countryCode!);
+    } else {
+      await prefs.remove(_kCountryCode);
+    }
+
+    state = locale;
+  }
+}

--- a/lib/config/locale/controller/locale_provider.g.dart
+++ b/lib/config/locale/controller/locale_provider.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'locale_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$localeNotifierHash() => r'3b75b1f23c095ff321864a5647531939518fdb62';
+
+/// See also [LocaleNotifier].
+@ProviderFor(LocaleNotifier)
+final localeNotifierProvider =
+    AutoDisposeNotifierProvider<LocaleNotifier, Locale>.internal(
+  LocaleNotifier.new,
+  name: r'localeNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$localeNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$LocaleNotifier = AutoDisposeNotifier<Locale>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:search_repositories/common_widget/toast/show_toast.dart';
 import 'package:search_repositories/config/key/secure_storage_key.dart';
+import 'package:search_repositories/config/util/color_style.dart';
 import 'package:search_repositories/config/util/custom_font_size.dart';
 import 'package:search_repositories/config/util/custom_padding.dart';
 import 'package:search_repositories/config/util/height_margin.dart';
@@ -10,6 +11,7 @@ import 'package:search_repositories/config/util/width_margin.dart';
 import 'package:search_repositories/feature/auth/controller/auth_controller.dart';
 import 'package:search_repositories/feature/auth/controller/secure_storage_controller.dart';
 import 'package:search_repositories/common_widget/loading_widget.dart';
+import 'package:search_repositories/config/locale/controller/locale_provider.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -20,12 +22,93 @@ class AuthLoginPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // 多言語対応
     final AppLocalizations? localizations = AppLocalizations.of(context);
+    // 現在の言語を取得
+    final currentLocale = ref.watch(localeNotifierProvider);
+
     // AppLocalizations が取得できていない場合はローディングを表示
     if (localizations == null) {
       return const Scaffold(body: Center(child: LoadingWidget()));
     }
 
     return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        actions: [
+          // 言語切り替えボタン
+          PopupMenuButton<Locale>(
+            tooltip: localizations.languageSettings,
+            onSelected: (Locale locale) {
+              ref.read(localeNotifierProvider.notifier).setLocale(locale);
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: CustomPadding.normal,
+              ),
+              child: Row(
+                children: [
+                  Text(
+                    localizations.languageSettings,
+                    style: const TextStyle(
+                      color: ColorStyle.blueAccent,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  WidthMargin.small,
+                  const Icon(Icons.language, color: ColorStyle.blueAccent),
+                ],
+              ),
+            ),
+            itemBuilder:
+                (BuildContext context) => <PopupMenuEntry<Locale>>[
+                  PopupMenuItem<Locale>(
+                    value: const Locale('en'),
+                    child: Row(
+                      children: [
+                        if (currentLocale.languageCode == 'en')
+                          const Icon(Icons.check, size: 18),
+                        WidthMargin.small,
+                        const Text('English'),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem<Locale>(
+                    value: const Locale('ja'),
+                    child: Row(
+                      children: [
+                        if (currentLocale.languageCode == 'ja')
+                          const Icon(Icons.check, size: 18),
+                        WidthMargin.small,
+                        const Text('日本語'),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem<Locale>(
+                    value: const Locale('ko'),
+                    child: Row(
+                      children: [
+                        if (currentLocale.languageCode == 'ko')
+                          const Icon(Icons.check, size: 18),
+                        WidthMargin.small,
+                        const Text('한국어'),
+                      ],
+                    ),
+                  ),
+                  PopupMenuItem<Locale>(
+                    value: const Locale('zh'),
+                    child: Row(
+                      children: [
+                        if (currentLocale.languageCode == 'zh')
+                          const Icon(Icons.check, size: 18),
+                        WidthMargin.small,
+                        const Text('中文'),
+                      ],
+                    ),
+                  ),
+                ],
+          ),
+        ],
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(CustomPadding.large),

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -15,6 +15,8 @@ import 'package:search_repositories/config/locale/controller/locale_provider.dar
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+part './part/language_toggle_button.dart';
+
 class AuthLoginPage extends ConsumerWidget {
   const AuthLoginPage({super.key});
 
@@ -32,80 +34,12 @@ class AuthLoginPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Colors.transparent,
         elevation: 0,
         actions: [
           // 言語切り替えボタン
-          PopupMenuButton<Locale>(
-            tooltip: localizations.languageSettings,
-            onSelected: (Locale locale) {
-              ref.read(localeNotifierProvider.notifier).setLocale(locale);
-            },
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: CustomPadding.normal,
-              ),
-              child: Row(
-                children: [
-                  Text(
-                    localizations.languageSettings,
-                    style: const TextStyle(
-                      color: ColorStyle.blueAccent,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  WidthMargin.small,
-                  const Icon(Icons.language, color: ColorStyle.blueAccent),
-                ],
-              ),
-            ),
-            itemBuilder:
-                (BuildContext context) => <PopupMenuEntry<Locale>>[
-                  PopupMenuItem<Locale>(
-                    value: const Locale('en'),
-                    child: Row(
-                      children: [
-                        if (currentLocale.languageCode == 'en')
-                          const Icon(Icons.check, size: 18),
-                        WidthMargin.small,
-                        const Text('English'),
-                      ],
-                    ),
-                  ),
-                  PopupMenuItem<Locale>(
-                    value: const Locale('ja'),
-                    child: Row(
-                      children: [
-                        if (currentLocale.languageCode == 'ja')
-                          const Icon(Icons.check, size: 18),
-                        WidthMargin.small,
-                        const Text('日本語'),
-                      ],
-                    ),
-                  ),
-                  PopupMenuItem<Locale>(
-                    value: const Locale('ko'),
-                    child: Row(
-                      children: [
-                        if (currentLocale.languageCode == 'ko')
-                          const Icon(Icons.check, size: 18),
-                        WidthMargin.small,
-                        const Text('한국어'),
-                      ],
-                    ),
-                  ),
-                  PopupMenuItem<Locale>(
-                    value: const Locale('zh'),
-                    child: Row(
-                      children: [
-                        if (currentLocale.languageCode == 'zh')
-                          const Icon(Icons.check, size: 18),
-                        WidthMargin.small,
-                        const Text('中文'),
-                      ],
-                    ),
-                  ),
-                ],
+          LanguageToggleButton(
+            localizations: localizations,
+            currentLocale: currentLocale,
           ),
         ],
       ),

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -9,12 +9,22 @@ import 'package:search_repositories/config/util/height_margin.dart';
 import 'package:search_repositories/config/util/width_margin.dart';
 import 'package:search_repositories/feature/auth/controller/auth_controller.dart';
 import 'package:search_repositories/feature/auth/controller/secure_storage_controller.dart';
+import 'package:search_repositories/common_widget/loading_widget.dart';
+
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class AuthLoginPage extends ConsumerWidget {
   const AuthLoginPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 多言語対応
+    final AppLocalizations? localizations = AppLocalizations.of(context);
+    // AppLocalizations が取得できていない場合はローディングを表示
+    if (localizations == null) {
+      return const Scaffold(body: Center(child: LoadingWidget()));
+    }
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -22,19 +32,19 @@ class AuthLoginPage extends ConsumerWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
             children: [
-              const Column(
+              Column(
                 children: [
                   Text(
-                    'ようこそ！',
-                    style: TextStyle(
+                    localizations.welcome,
+                    style: const TextStyle(
                       fontSize: CustomFontSize.largest,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
                   HeightMargin.large,
                   Text(
-                    'このアプリではGitHubのリポジトリを検索できます。機能を使うにはGitHub連携が必要です。',
-                    style: TextStyle(fontSize: CustomFontSize.medium),
+                    localizations.appDescription,
+                    style: const TextStyle(fontSize: CustomFontSize.medium),
                   ),
                 ],
               ),
@@ -52,7 +62,7 @@ class AuthLoginPage extends ConsumerWidget {
                   ),
                   onPressed: () async {
                     //TODO: ローディングダイアログの表示
-                    await _signInWithGitHub(ref);
+                    await _signInWithGitHub(ref, localizations);
                   },
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -65,9 +75,9 @@ class AuthLoginPage extends ConsumerWidget {
                         color: Theme.of(context).colorScheme.primary,
                       ),
                       WidthMargin.normal,
-                      const Text(
-                        'Sign in to GitHub',
-                        style: TextStyle(fontSize: CustomFontSize.medium),
+                      Text(
+                        localizations.signInGitHub,
+                        style: const TextStyle(fontSize: CustomFontSize.medium),
                       ),
                     ],
                   ),
@@ -81,12 +91,15 @@ class AuthLoginPage extends ConsumerWidget {
     );
   }
 
-  Future<void> _signInWithGitHub(WidgetRef ref) async {
+  Future<void> _signInWithGitHub(
+    WidgetRef ref,
+    AppLocalizations localizations,
+  ) async {
     final UserCredential? credentail =
         await ref.read(authControllerProvider.notifier).signInWithGitHub();
     if (credentail != null) {
       // 認証成功
-      showToast('接続成功');
+      showToast(localizations.connectionSuccess);
       if (((credentail.credential?.accessToken) != null)) {
         await ref
             .read(secureStorageControllerProvider.notifier)
@@ -95,11 +108,11 @@ class AuthLoginPage extends ConsumerWidget {
               value: credentail.credential?.accessToken ?? '',
             );
       } else {
-        showToast('トークン取得に失敗');
+        showToast(localizations.tokenFailure);
       }
     } else {
       // 認証失敗
-      showToast('接続に失敗');
+      showToast(localizations.connectionFailure);
     }
   }
 }

--- a/lib/feature/auth/view/part/language_toggle_button.dart
+++ b/lib/feature/auth/view/part/language_toggle_button.dart
@@ -1,0 +1,79 @@
+part of '../auth_login_page.dart';
+
+class LanguageToggleButton extends ConsumerWidget {
+  const LanguageToggleButton({
+    super.key,
+    required this.localizations,
+    required this.currentLocale,
+  });
+
+  final AppLocalizations? localizations;
+  final Locale currentLocale;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PopupMenuButton<Locale>(
+      tooltip: localizations!.languageSettings,
+      onSelected: (Locale locale) {
+        ref.read(localeNotifierProvider.notifier).setLocale(locale);
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: CustomPadding.normal),
+        child: Row(
+          children: [
+            Text(
+              localizations!.languageSettings,
+              style: const TextStyle(
+                color: ColorStyle.blueAccent,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            WidthMargin.small,
+            const Icon(Icons.language, color: ColorStyle.blueAccent),
+          ],
+        ),
+      ),
+      itemBuilder:
+          (BuildContext context) => <PopupMenuEntry<Locale>>[
+            _languagePopupMenuItem(
+              currentLocale: currentLocale,
+              languageCode: 'ja',
+              languageName: '日本語',
+            ),
+            _languagePopupMenuItem(
+              currentLocale: currentLocale,
+              languageCode: 'en',
+              languageName: 'English',
+            ),
+            _languagePopupMenuItem(
+              currentLocale: currentLocale,
+              languageCode: 'ko',
+              languageName: '한국어',
+            ),
+            _languagePopupMenuItem(
+              currentLocale: currentLocale,
+              languageCode: 'zh',
+              languageName: '中文',
+            ),
+          ],
+    );
+  }
+
+  PopupMenuItem<Locale> _languagePopupMenuItem({
+    required Locale currentLocale,
+    required String languageCode,
+    required String languageName,
+  }) {
+    return PopupMenuItem<Locale>(
+      value: Locale(languageCode),
+      child: Row(
+        children: [
+          if (currentLocale.languageCode == languageCode)
+            const Icon(Icons.check, size: 18),
+          WidthMargin.small,
+          Text(languageName),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/github/view/part/drawer_widget.dart
+++ b/lib/feature/github/view/part/drawer_widget.dart
@@ -42,12 +42,14 @@ class DrawerWidget extends ConsumerWidget {
           ),
           // 言語設定ボタン
           LanguageToggleTile(currentLocale: currentLocale),
+          // ログアウト
           ListTile(
             title: Text(localizations.logout),
             onTap: () async {
               _logout(context, ref, localizations);
             },
           ),
+          // アカウント削除
           ListTile(
             title: Text(localizations.deleteAccount),
             onTap: () async {

--- a/lib/feature/github/view/part/drawer_widget.dart
+++ b/lib/feature/github/view/part/drawer_widget.dart
@@ -5,6 +5,10 @@ class DrawerWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 現在の言語を取得
+    final currentLocale = ref.watch(localeNotifierProvider);
+    final localizations = AppLocalizations.of(context);
+
     return Drawer(
       child: ListView(
         padding: EdgeInsets.zero,
@@ -30,6 +34,52 @@ class DrawerWidget extends ConsumerWidget {
                     .setThemeMode(value ? ThemeMode.dark : ThemeMode.light);
               },
             ),
+          ),
+          // 言語設定ボタン
+          ExpansionTile(
+            title: const Text('言語設定'),
+            children: [
+              RadioListTile<Locale>(
+                title: const Text('English'),
+                value: const Locale('en'),
+                groupValue: currentLocale,
+                onChanged: (Locale? value) {
+                  if (value != null) {
+                    ref.read(localeNotifierProvider.notifier).setLocale(value);
+                  }
+                },
+              ),
+              RadioListTile<Locale>(
+                title: const Text('日本語'),
+                value: const Locale('ja'),
+                groupValue: currentLocale,
+                onChanged: (Locale? value) {
+                  if (value != null) {
+                    ref.read(localeNotifierProvider.notifier).setLocale(value);
+                  }
+                },
+              ),
+              RadioListTile<Locale>(
+                title: const Text('한국어'),
+                value: const Locale('ko'),
+                groupValue: currentLocale,
+                onChanged: (Locale? value) {
+                  if (value != null) {
+                    ref.read(localeNotifierProvider.notifier).setLocale(value);
+                  }
+                },
+              ),
+              RadioListTile<Locale>(
+                title: const Text('中文'),
+                value: const Locale('zh'),
+                groupValue: currentLocale,
+                onChanged: (Locale? value) {
+                  if (value != null) {
+                    ref.read(localeNotifierProvider.notifier).setLocale(value);
+                  }
+                },
+              ),
+            ],
           ),
           ListTile(
             title: const Text('ログアウト'),

--- a/lib/feature/github/view/part/drawer_widget.dart
+++ b/lib/feature/github/view/part/drawer_widget.dart
@@ -35,43 +35,7 @@ class DrawerWidget extends ConsumerWidget {
             ),
           ),
           // 言語設定ボタン
-          ExpansionTile(
-            title: const Text('言語設定'),
-            children: [
-              RadioListTile<Locale>(
-                title: const Text('日本語'),
-                value: const Locale('ja'),
-                groupValue: currentLocale,
-                onChanged: (Locale? value) {
-                  _setLocale(value, ref);
-                },
-              ),
-              RadioListTile<Locale>(
-                title: const Text('English'),
-                value: const Locale('en'),
-                groupValue: currentLocale,
-                onChanged: (Locale? value) {
-                  _setLocale(value, ref);
-                },
-              ),
-              RadioListTile<Locale>(
-                title: const Text('한국어'),
-                value: const Locale('ko'),
-                groupValue: currentLocale,
-                onChanged: (Locale? value) {
-                  _setLocale(value, ref);
-                },
-              ),
-              RadioListTile<Locale>(
-                title: const Text('中文'),
-                value: const Locale('zh'),
-                groupValue: currentLocale,
-                onChanged: (Locale? value) {
-                  _setLocale(value, ref);
-                },
-              ),
-            ],
-          ),
+          LanguageToggleTile(currentLocale: currentLocale),
           ListTile(
             title: const Text('ログアウト'),
             onTap: () async {
@@ -87,12 +51,6 @@ class DrawerWidget extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  void _setLocale(Locale? value, WidgetRef ref) {
-    if (value != null) {
-      ref.read(localeNotifierProvider.notifier).setLocale(value);
-    }
   }
 
   void _logout(BuildContext context, WidgetRef ref) {

--- a/lib/feature/github/view/part/drawer_widget.dart
+++ b/lib/feature/github/view/part/drawer_widget.dart
@@ -7,23 +7,29 @@ class DrawerWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // 現在の言語を取得
     final currentLocale = ref.watch(localeNotifierProvider);
+    final localizations = AppLocalizations.of(context);
+
+    // localizationsがnullの場合はエラー防止のためローディング表示
+    if (localizations == null) {
+      return const Drawer(child: Center(child: CircularProgressIndicator()));
+    }
 
     return Drawer(
       child: ListView(
         padding: EdgeInsets.zero,
         children: [
-          const DrawerHeader(
+          DrawerHeader(
             child: Text(
-              'GitHubリポジトリ検索',
-              style: TextStyle(fontSize: CustomFontSize.large),
+              localizations.appTitle,
+              style: const TextStyle(fontSize: CustomFontSize.large),
             ),
           ),
           // ダークモードの切り替え
           ListTile(
             title: Text(
               (ref.watch(themeControllerProvider) == ThemeMode.dark)
-                  ? 'ダークモード'
-                  : 'ライトモード',
+                  ? localizations.darkMode
+                  : localizations.lightMode,
             ),
             trailing: Switch(
               value: ref.watch(themeControllerProvider) == ThemeMode.dark,
@@ -37,15 +43,15 @@ class DrawerWidget extends ConsumerWidget {
           // 言語設定ボタン
           LanguageToggleTile(currentLocale: currentLocale),
           ListTile(
-            title: const Text('ログアウト'),
+            title: Text(localizations.logout),
             onTap: () async {
-              _logout(context, ref);
+              _logout(context, ref, localizations);
             },
           ),
           ListTile(
-            title: const Text('削除'),
+            title: Text(localizations.deleteAccount),
             onTap: () async {
-              _deleteAccount(context, ref);
+              _deleteAccount(context, ref, localizations);
             },
           ),
         ],
@@ -53,30 +59,38 @@ class DrawerWidget extends ConsumerWidget {
     );
   }
 
-  void _logout(BuildContext context, WidgetRef ref) {
+  void _logout(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations localizations,
+  ) {
     return showConfirmDialog(
       context: context,
-      text: 'ログアウトしますか？',
+      text: localizations.logoutConfirmation,
       onPressed: () async {
         context.pop();
-        showLoadingDialog('ログアウト中...');
+        showLoadingDialog(localizations.loggingOut);
         await ref.read(authControllerProvider.notifier).signOut();
         hideLoadingDialog();
-        showToast('ログアウトしました');
+        showToast(localizations.loggedOut);
       },
     );
   }
 
-  void _deleteAccount(BuildContext context, WidgetRef ref) {
+  void _deleteAccount(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations localizations,
+  ) {
     return showConfirmDialog(
       context: context,
-      text: '本当にアカウントを削除しますか？',
+      text: localizations.deleteConfirmation,
       onPressed: () async {
         context.pop();
-        showLoadingDialog('削除中...');
+        showLoadingDialog(localizations.deleting);
         await ref.read(authControllerProvider.notifier).delete();
         hideLoadingDialog();
-        showToast('アカウントを削除しました');
+        showToast(localizations.accountDeleted);
       },
     );
   }

--- a/lib/feature/github/view/part/drawer_widget.dart
+++ b/lib/feature/github/view/part/drawer_widget.dart
@@ -7,7 +7,6 @@ class DrawerWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // 現在の言語を取得
     final currentLocale = ref.watch(localeNotifierProvider);
-    final localizations = AppLocalizations.of(context);
 
     return Drawer(
       child: ListView(
@@ -40,23 +39,19 @@ class DrawerWidget extends ConsumerWidget {
             title: const Text('言語設定'),
             children: [
               RadioListTile<Locale>(
-                title: const Text('English'),
-                value: const Locale('en'),
-                groupValue: currentLocale,
-                onChanged: (Locale? value) {
-                  if (value != null) {
-                    ref.read(localeNotifierProvider.notifier).setLocale(value);
-                  }
-                },
-              ),
-              RadioListTile<Locale>(
                 title: const Text('日本語'),
                 value: const Locale('ja'),
                 groupValue: currentLocale,
                 onChanged: (Locale? value) {
-                  if (value != null) {
-                    ref.read(localeNotifierProvider.notifier).setLocale(value);
-                  }
+                  _setLocale(value, ref);
+                },
+              ),
+              RadioListTile<Locale>(
+                title: const Text('English'),
+                value: const Locale('en'),
+                groupValue: currentLocale,
+                onChanged: (Locale? value) {
+                  _setLocale(value, ref);
                 },
               ),
               RadioListTile<Locale>(
@@ -64,9 +59,7 @@ class DrawerWidget extends ConsumerWidget {
                 value: const Locale('ko'),
                 groupValue: currentLocale,
                 onChanged: (Locale? value) {
-                  if (value != null) {
-                    ref.read(localeNotifierProvider.notifier).setLocale(value);
-                  }
+                  _setLocale(value, ref);
                 },
               ),
               RadioListTile<Locale>(
@@ -74,9 +67,7 @@ class DrawerWidget extends ConsumerWidget {
                 value: const Locale('zh'),
                 groupValue: currentLocale,
                 onChanged: (Locale? value) {
-                  if (value != null) {
-                    ref.read(localeNotifierProvider.notifier).setLocale(value);
-                  }
+                  _setLocale(value, ref);
                 },
               ),
             ],
@@ -96,6 +87,12 @@ class DrawerWidget extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  void _setLocale(Locale? value, WidgetRef ref) {
+    if (value != null) {
+      ref.read(localeNotifierProvider.notifier).setLocale(value);
+    }
   }
 
   void _logout(BuildContext context, WidgetRef ref) {

--- a/lib/feature/github/view/part/language_toggle_tile.dart
+++ b/lib/feature/github/view/part/language_toggle_tile.dart
@@ -7,8 +7,14 @@ class LanguageToggleTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final localizations = AppLocalizations.of(context);
+
+    if (localizations == null) {
+      return const SizedBox.shrink();
+    }
+
     return ExpansionTile(
-      title: const Text('言語設定'),
+      title: Text(localizations.languageSettings),
       children: [
         RadioListTile<Locale>(
           title: const Text('日本語'),

--- a/lib/feature/github/view/part/language_toggle_tile.dart
+++ b/lib/feature/github/view/part/language_toggle_tile.dart
@@ -1,0 +1,54 @@
+part of '../repository_list_page.dart';
+
+class LanguageToggleTile extends ConsumerWidget {
+  const LanguageToggleTile({super.key, required this.currentLocale});
+
+  final Locale currentLocale;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ExpansionTile(
+      title: const Text('言語設定'),
+      children: [
+        RadioListTile<Locale>(
+          title: const Text('日本語'),
+          value: const Locale('ja'),
+          groupValue: currentLocale,
+          onChanged: (Locale? value) {
+            _setLocale(value, ref);
+          },
+        ),
+        RadioListTile<Locale>(
+          title: const Text('English'),
+          value: const Locale('en'),
+          groupValue: currentLocale,
+          onChanged: (Locale? value) {
+            _setLocale(value, ref);
+          },
+        ),
+        RadioListTile<Locale>(
+          title: const Text('한국어'),
+          value: const Locale('ko'),
+          groupValue: currentLocale,
+          onChanged: (Locale? value) {
+            _setLocale(value, ref);
+          },
+        ),
+        RadioListTile<Locale>(
+          title: const Text('中文'),
+          value: const Locale('zh'),
+          groupValue: currentLocale,
+          onChanged: (Locale? value) {
+            _setLocale(value, ref);
+          },
+        ),
+      ],
+    );
+  }
+
+  void _setLocale(Locale? value, WidgetRef ref) {
+    if (value != null) {
+      ref.read(localeNotifierProvider.notifier).setLocale(value);
+    }
+  }
+}

--- a/lib/feature/github/view/part/repository_list_tile.dart
+++ b/lib/feature/github/view/part/repository_list_tile.dart
@@ -7,6 +7,11 @@ class RepositoryListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+
+    // localizationsがnullの場合は代替テキストを使用
+    final noDescriptionText = localizations?.noDescription ?? '詳細がありません';
+
     return InkWell(
       onTap: () {
         context.pushNamed(AppRoute.repositoryDetail.name, extra: repo);
@@ -25,7 +30,7 @@ class RepositoryListTile extends StatelessWidget {
               ),
             ),
             subtitle: Text(
-              repo.description ?? '詳細がありません',
+              repo.description ?? noDescriptionText,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(fontSize: CustomFontSize.small),

--- a/lib/feature/github/view/repository_detail_page.dart
+++ b/lib/feature/github/view/repository_detail_page.dart
@@ -12,6 +12,8 @@ import 'package:search_repositories/common_widget/icon_info_widget.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:search_repositories/function/launch_url.dart';
 
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 part 'part/icon_image.dart';
 
 class RepositoryDetailPage extends ConsumerWidget {
@@ -22,6 +24,16 @@ class RepositoryDetailPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     const double iconSize = 36;
+
+    /*
+    多言語対応
+    */
+    final AppLocalizations? localizations = AppLocalizations.of(context);
+    // AppLocalizations が取得できていない場合はローディングを表示
+    if (localizations == null) {
+      return const Scaffold(body: Center(child: LoadingWidget()));
+    }
+
     return Scaffold(
       appBar: AppBar(
         actions: [

--- a/lib/feature/github/view/repository_detail_page.dart
+++ b/lib/feature/github/view/repository_detail_page.dart
@@ -82,7 +82,7 @@ class RepositoryDetailPage extends ConsumerWidget {
                   SizedBox(
                     width: 70,
                     child: Text(
-                      '開発者',
+                      localizations.developer,
                       style: TextStyle(
                         fontSize: CustomFontSize.small,
                         color: Theme.of(context).colorScheme.tertiary,
@@ -101,7 +101,7 @@ class RepositoryDetailPage extends ConsumerWidget {
                   SizedBox(
                     width: 70,
                     child: Text(
-                      '開発言語',
+                      localizations.language,
                       style: TextStyle(
                         fontSize: CustomFontSize.small,
                         color: Theme.of(context).colorScheme.tertiary,
@@ -110,7 +110,7 @@ class RepositoryDetailPage extends ConsumerWidget {
                   ),
                   WidthMargin.small,
                   Text(
-                    repository.language ?? '不明',
+                    repository.language ?? localizations.unknown,
                     style: const TextStyle(fontSize: CustomFontSize.small),
                   ),
                 ],
@@ -118,12 +118,12 @@ class RepositoryDetailPage extends ConsumerWidget {
               HeightMargin.normal,
               // 説明文
               ReadMoreText(
-                repository.description ?? '詳細がありません',
+                repository.description ?? localizations.noDescription,
                 textAlign: TextAlign.start,
                 trimLines: 1,
                 trimMode: TrimMode.Line,
-                trimCollapsedText: ' さらに表示',
-                trimExpandedText: ' 折りたたむ',
+                trimCollapsedText: localizations.showMore,
+                trimExpandedText: localizations.showLess,
                 style: const TextStyle(fontSize: CustomFontSize.normal),
                 moreStyle: const TextStyle(
                   fontSize: CustomFontSize.small,

--- a/lib/feature/github/view/repository_list_page.dart
+++ b/lib/feature/github/view/repository_list_page.dart
@@ -24,6 +24,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 part 'part/repository_list_tile.dart';
 part 'part/drawer_widget.dart';
+part 'part/language_toggle_tile.dart';
 
 class RepositoryListPage extends HookConsumerWidget {
   const RepositoryListPage({super.key});

--- a/lib/feature/github/view/repository_list_page.dart
+++ b/lib/feature/github/view/repository_list_page.dart
@@ -18,6 +18,7 @@ import 'package:search_repositories/feature/auth/controller/auth_controller.dart
 import 'package:search_repositories/feature/github/controller/github_controller.dart';
 import 'package:search_repositories/feature/github/model/api_response.dart';
 import 'package:search_repositories/common_widget/icon_info_widget.dart';
+import 'package:search_repositories/config/locale/controller/locale_provider.dart';
 
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 

--- a/lib/feature/github/view/repository_list_page.dart
+++ b/lib/feature/github/view/repository_list_page.dart
@@ -19,6 +19,8 @@ import 'package:search_repositories/feature/github/controller/github_controller.
 import 'package:search_repositories/feature/github/model/api_response.dart';
 import 'package:search_repositories/common_widget/icon_info_widget.dart';
 
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 part 'part/repository_list_tile.dart';
 part 'part/drawer_widget.dart';
 
@@ -30,6 +32,17 @@ class RepositoryListPage extends HookConsumerWidget {
     final TextEditingController searchTextController =
         useTextEditingController();
     final ValueNotifier<String> keyword = useState<String>('');
+
+    /*
+    多言語対応
+    */
+    // AppLocalizations が取得できていない場合はローディングを表示
+    final AppLocalizations? localizations = AppLocalizations.of(context);
+    // AppLocalizations が取得できていない場合はローディングを表示
+    if (localizations == null) {
+      return const Scaffold(body: Center(child: LoadingWidget()));
+    }
+
     return UnFocusKeyBoardWidget(
       child: Scaffold(
         drawer: const DrawerWidget(),
@@ -37,7 +50,7 @@ class RepositoryListPage extends HookConsumerWidget {
           title: TextField(
             controller: searchTextController,
             decoration: noneBorderTextFieldDecoration(
-              label: 'レポジトリを検索',
+              label: localizations.searchTextFieldLabel,
               prefixIconOnPressed: null,
               prefixIcon: const SizedBox.shrink(),
               suffixIconOnPressed:

--- a/lib/feature/github/view/repository_list_page.dart
+++ b/lib/feature/github/view/repository_list_page.dart
@@ -38,7 +38,6 @@ class RepositoryListPage extends HookConsumerWidget {
     /*
     多言語対応
     */
-    // AppLocalizations が取得できていない場合はローディングを表示
     final AppLocalizations? localizations = AppLocalizations.of(context);
     // AppLocalizations が取得できていない場合はローディングを表示
     if (localizations == null) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,16 @@
 {
   "@@locale":"en",
-  "searchTextFieldLabel":"Search repositories"
+  "searchTextFieldLabel":"Search repositories",
+  "appTitle": "GitHub Repository Search",
+  "darkMode": "Dark Mode",
+  "lightMode": "Light Mode",
+  "languageSettings": "Language Settings",
+  "logout": "Logout",
+  "deleteAccount": "Delete Account",
+  "logoutConfirmation": "Are you sure you want to log out?",
+  "deleteConfirmation": "Are you sure you want to delete your account?",
+  "loggingOut": "Logging out...",
+  "loggedOut": "Logged out",
+  "deleting": "Deleting...",
+  "accountDeleted": "Account deleted"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -12,5 +12,12 @@
   "loggingOut": "Logging out...",
   "loggedOut": "Logged out",
   "deleting": "Deleting...",
-  "accountDeleted": "Account deleted"
+  "accountDeleted": "Account deleted",
+  
+  "developer": "Developer",
+  "language": "Language",
+  "unknown": "Unknown",
+  "noDescription": "No description available",
+  "showMore": " Show more",
+  "showLess": " Show less"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -26,5 +26,9 @@
   "signInGitHub": "Sign in to GitHub",
   "connectionSuccess": "Connection successful",
   "tokenFailure": "Failed to get token",
-  "connectionFailure": "Connection failed"
+  "connectionFailure": "Connection failed",
+  
+  "confirmTitle": "Confirm",
+  "yes": "Yes",
+  "no": "No"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale":"en",
+  "SearchTextFieldLabel":"Search repositories"
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -19,5 +19,12 @@
   "unknown": "Unknown",
   "noDescription": "No description available",
   "showMore": " Show more",
-  "showLess": " Show less"
+  "showLess": " Show less",
+  
+  "welcome": "Welcome!",
+  "appDescription": "This app allows you to search GitHub repositories. GitHub integration is required to use this feature.",
+  "signInGitHub": "Sign in to GitHub",
+  "connectionSuccess": "Connection successful",
+  "tokenFailure": "Failed to get token",
+  "connectionFailure": "Connection failed"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,4 @@
 {
   "@@locale":"en",
-  "SearchTextFieldLabel":"Search repositories"
+  "searchTextFieldLabel":"Search repositories"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,4 +1,4 @@
 {
   "@@locale":"ja",
-  "SearchTextFieldLabel":"レポジトリを検索"
+  "searchTextFieldLabel":"レポジトリを検索"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale":"ja",
+  "SearchTextFieldLabel":"レポジトリを検索"
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -19,5 +19,12 @@
   "unknown": "不明",
   "noDescription": "詳細がありません",
   "showMore": " さらに表示",
-  "showLess": " 折りたたむ"
+  "showLess": " 折りたたむ",
+  
+  "welcome": "ようこそ！",
+  "appDescription": "このアプリではGitHubのリポジトリを検索できます。機能を使うにはGitHub連携が必要です。",
+  "signInGitHub": "GitHubでログイン",
+  "connectionSuccess": "接続成功",
+  "tokenFailure": "トークン取得に失敗",
+  "connectionFailure": "接続に失敗"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -12,5 +12,12 @@
   "loggingOut": "ログアウト中...",
   "loggedOut": "ログアウトしました",
   "deleting": "削除中...",
-  "accountDeleted": "アカウントを削除しました"
+  "accountDeleted": "アカウントを削除しました",
+  
+  "developer": "開発者",
+  "language": "開発言語",
+  "unknown": "不明",
+  "noDescription": "詳細がありません",
+  "showMore": " さらに表示",
+  "showLess": " 折りたたむ"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -26,5 +26,9 @@
   "signInGitHub": "GitHubでログイン",
   "connectionSuccess": "接続成功",
   "tokenFailure": "トークン取得に失敗",
-  "connectionFailure": "接続に失敗"
+  "connectionFailure": "接続に失敗",
+  
+  "confirmTitle": "確認",
+  "yes": "はい",
+  "no": "いいえ"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,4 +1,16 @@
 {
   "@@locale":"ja",
-  "searchTextFieldLabel":"レポジトリを検索"
+  "searchTextFieldLabel":"レポジトリを検索",
+  "appTitle": "GitHubリポジトリ検索",
+  "darkMode": "ダークモード",
+  "lightMode": "ライトモード",
+  "languageSettings": "言語設定",
+  "logout": "ログアウト",
+  "deleteAccount": "アカウント削除",
+  "logoutConfirmation": "ログアウトしますか？",
+  "deleteConfirmation": "本当にアカウントを削除しますか？",
+  "loggingOut": "ログアウト中...",
+  "loggedOut": "ログアウトしました",
+  "deleting": "削除中...",
+  "accountDeleted": "アカウントを削除しました"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1,4 +1,4 @@
 {
   "@@locale":"ko",
-  "SearchTextFieldLabel":"레포지토리 검색"
+  "searchTextFieldLabel":"레포지토리 검색"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1,4 +1,16 @@
 {
   "@@locale":"ko",
-  "searchTextFieldLabel":"레포지토리 검색"
+  "searchTextFieldLabel":"레포지토리 검색",
+  "appTitle": "GitHub 레포지토리 검색",
+  "darkMode": "다크 모드",
+  "lightMode": "라이트 모드",
+  "languageSettings": "언어 설정",
+  "logout": "로그아웃",
+  "deleteAccount": "계정 삭제",
+  "logoutConfirmation": "로그아웃 하시겠습니까?",
+  "deleteConfirmation": "정말로 계정을 삭제하시겠습니까?",
+  "loggingOut": "로그아웃 중...",
+  "loggedOut": "로그아웃 되었습니다",
+  "deleting": "삭제 중...",
+  "accountDeleted": "계정이 삭제되었습니다"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale":"ko",
+  "SearchTextFieldLabel":"레포지토리 검색"
+}

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -19,5 +19,12 @@
   "unknown": "알 수 없음",
   "noDescription": "설명이 없습니다",
   "showMore": " 더 보기",
-  "showLess": " 접기"
+  "showLess": " 접기",
+  
+  "welcome": "환영합니다!",
+  "appDescription": "이 앱에서는 GitHub 레포지토리를 검색할 수 있습니다. 이 기능을 사용하려면 GitHub 연동이 필요합니다.",
+  "signInGitHub": "GitHub로 로그인",
+  "connectionSuccess": "연결 성공",
+  "tokenFailure": "토큰 가져오기 실패",
+  "connectionFailure": "연결 실패"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -26,5 +26,9 @@
   "signInGitHub": "GitHub로 로그인",
   "connectionSuccess": "연결 성공",
   "tokenFailure": "토큰 가져오기 실패",
-  "connectionFailure": "연결 실패"
+  "connectionFailure": "연결 실패",
+  
+  "confirmTitle": "확인",
+  "yes": "예",
+  "no": "아니오"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -12,5 +12,12 @@
   "loggingOut": "로그아웃 중...",
   "loggedOut": "로그아웃 되었습니다",
   "deleting": "삭제 중...",
-  "accountDeleted": "계정이 삭제되었습니다"
+  "accountDeleted": "계정이 삭제되었습니다",
+  
+  "developer": "개발자",
+  "language": "개발 언어",
+  "unknown": "알 수 없음",
+  "noDescription": "설명이 없습니다",
+  "showMore": " 더 보기",
+  "showLess": " 접기"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,4 +1,16 @@
 {
   "@@locale":"zh",
-  "searchTextFieldLabel":"搜索仓库"
+  "searchTextFieldLabel":"搜索仓库",
+  "appTitle": "GitHub仓库搜索",
+  "darkMode": "深色模式",
+  "lightMode": "浅色模式",
+  "languageSettings": "语言设置",
+  "logout": "登出",
+  "deleteAccount": "删除账户",
+  "logoutConfirmation": "确定要登出吗？",
+  "deleteConfirmation": "确定要删除账户吗？",
+  "loggingOut": "正在登出...",
+  "loggedOut": "已登出",
+  "deleting": "正在删除...",
+  "accountDeleted": "账户已删除"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,4 @@
+{
+  "@@locale":"zh",
+  "SearchTextFieldLabel":"搜索仓库"
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -26,5 +26,9 @@
   "signInGitHub": "登录GitHub",
   "connectionSuccess": "连接成功",
   "tokenFailure": "获取令牌失败",
-  "connectionFailure": "连接失败"
+  "connectionFailure": "连接失败",
+  
+  "confirmTitle": "确认",
+  "yes": "是",
+  "no": "否"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -12,5 +12,12 @@
   "loggingOut": "正在登出...",
   "loggedOut": "已登出",
   "deleting": "正在删除...",
-  "accountDeleted": "账户已删除"
+  "accountDeleted": "账户已删除",
+  
+  "developer": "开发者",
+  "language": "开发语言",
+  "unknown": "未知",
+  "noDescription": "没有描述",
+  "showMore": " 显示更多",
+  "showLess": " 收起"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,4 +1,4 @@
 {
   "@@locale":"zh",
-  "SearchTextFieldLabel":"搜索仓库"
+  "searchTextFieldLabel":"搜索仓库"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -19,5 +19,12 @@
   "unknown": "未知",
   "noDescription": "没有描述",
   "showMore": " 显示更多",
-  "showLess": " 收起"
+  "showLess": " 收起",
+  
+  "welcome": "欢迎！",
+  "appDescription": "这个应用可以搜索GitHub仓库。使用此功能需要GitHub集成。",
+  "signInGitHub": "登录GitHub",
+  "connectionSuccess": "连接成功",
+  "tokenFailure": "获取令牌失败",
+  "connectionFailure": "连接失败"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_repositories/config/firebase/firebase_options.dart';
+import 'package:search_repositories/config/locale/controller/locale_provider.dart';
 import 'package:search_repositories/config/routing/app_router.dart';
 import 'package:search_repositories/config/theme/app_theme.dart';
 import 'package:search_repositories/config/theme/theme_controller.dart';
@@ -35,9 +36,7 @@ class MyApp extends ConsumerWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-
-      locale: const Locale('en'), //初期言語
-
+      locale: ref.watch(localeNotifierProvider), //初期言語
       localeResolutionCallback: (locale, supportedLocales) {
         if (locale == null) {
           return const Locale('en'); // デフォルトを日本語に設定

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,13 +34,21 @@ class MyApp extends ConsumerWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: const [
-        Locale('en'),
-        Locale('ja'),
-        Locale('ko'),
-        Locale('zh'),
-      ],
-      locale: null,
+      supportedLocales: AppLocalizations.supportedLocales,
+
+      locale: const Locale('en'), //初期言語
+
+      localeResolutionCallback: (locale, supportedLocales) {
+        if (locale == null) {
+          return const Locale('en'); // デフォルトを日本語に設定
+        }
+        for (final supportedLocale in supportedLocales) {
+          if (supportedLocale.languageCode == locale.languageCode) {
+            return supportedLocale;
+          }
+        }
+        return const Locale('en'); // どの言語もマッチしない場合、日本語を適用
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,8 @@ import 'package:search_repositories/config/firebase/firebase_options.dart';
 import 'package:search_repositories/config/routing/app_router.dart';
 import 'package:search_repositories/config/theme/app_theme.dart';
 import 'package:search_repositories/config/theme/theme_controller.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -26,6 +28,19 @@ class MyApp extends ConsumerWidget {
       themeMode: themeMode,
       routerConfig: appRouter,
       debugShowCheckedModeBanner: false,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('ja'),
+        Locale('ko'),
+        Locale('zh'),
+      ],
+      locale: null,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -342,16 +342,8 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
-  flutter_localization:
-    dependency: "direct main"
-    description:
-      name: flutter_localization
-      sha256: "987faf0a6c13a267202b28d3ed680647e234245ead1a1c1f95f87e86c6f12490"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.2"
   flutter_localizations:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -1010,14 +1002,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  universal_io:
-    dependency: transitive
-    description:
-      name: universal_io
-      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -342,6 +342,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localization:
+    dependency: "direct main"
+    description:
+      name: flutter_localization
+      sha256: "987faf0a6c13a267202b28d3ed680647e234245ead1a1c1f95f87e86c6f12490"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -496,6 +509,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -989,6 +1010,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks:
-  flutter_localizations:
   hooks_riverpod:
   flutter_riverpod:
   riverpod_annotation:
@@ -28,7 +27,8 @@ dependencies:
   flutter_secure_storage: ^9.2.4
   fluttertoast: ^8.2.12
   shared_preferences: ^2.5.3
-  intl: ^0.18.1
+  intl:
+  flutter_localization: ^0.3.2
   
 
 dev_dependencies:
@@ -42,6 +42,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  generate: true
 
   assets:
     - assets/github_icon/github-mark.png

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,8 @@ dependencies:
   fluttertoast: ^8.2.12
   shared_preferences: ^2.5.3
   intl:
-  flutter_localization: ^0.3.2
+  flutter_localizations:
+    sdk: flutter
   
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_hooks:
+  flutter_localizations:
   hooks_riverpod:
   flutter_riverpod:
   riverpod_annotation:
@@ -27,6 +28,7 @@ dependencies:
   flutter_secure_storage: ^9.2.4
   fluttertoast: ^8.2.12
   shared_preferences: ^2.5.3
+  intl: ^0.18.1
   
 
 dev_dependencies:


### PR DESCRIPTION
# このPRの対応範囲
【追加8点】
1. 多言語設定のファイルを作成
2. 言語をローカルデータに保存し、状態を管理するproviderを作成
3. 言語設定切り替えボタンを認証ページと、ハンバーガーメニューに配置
4. ハンバーガーメニュー画面を多言語対応
5. リポジトリ一覧画面を多言語対応
6. リポジトリ詳細画面を多言語対応
7. 確認ダイアログを多言語対応
