### PR TITLE
auth画面、ロジックのリファクタ

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,6 +33,7 @@ linter:
     # コード構造と可読性
     lines_longer_than_80_chars: true  # 80文字を超える行を警告
     require_trailing_commas: true  # 複数行の引数リストで末尾カンマを必須に
+    directives_ordering: true  # インポートの順序を整理
     
     # Nullセーフティ
     avoid_null_checks_in_equality_operators: true  # 等価演算子では不要なnullチェックを避ける

--- a/lib/config/key/secure_storage_key.dart
+++ b/lib/config/key/secure_storage_key.dart
@@ -1,3 +1,6 @@
 class SecureStorageKey {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  SecureStorageKey._();
+
   static String githubAccessToken = 'github_access_token';
 }

--- a/lib/config/util/app_assets.dart
+++ b/lib/config/util/app_assets.dart
@@ -1,0 +1,8 @@
+/// アプリ全体のアセットパスを管理するクラス
+class AppAssets {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  AppAssets._();
+
+  /// アイコン画像のパス
+  static const String githubIcon = 'assets/github_icon/github-mark.png';
+}

--- a/lib/config/util/color_style.dart
+++ b/lib/config/util/color_style.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 
 class ColorStyle {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  ColorStyle._();
+
   // モノトーン系
   static const white = Color.fromARGB(255, 255, 255, 255);
   static const darkBlack = Color.fromARGB(255, 16, 16, 16);

--- a/lib/config/util/custom_font_size.dart
+++ b/lib/config/util/custom_font_size.dart
@@ -1,4 +1,7 @@
 class CustomFontSize {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  CustomFontSize._();
+
   static const double smallest = 10; //メッセージルームの時間
   static const double mini = 12; //カードの中の小さい説明など
   static const double small = 14; //小さい文字。（小見出しの下の文字など）

--- a/lib/config/util/custom_padding.dart
+++ b/lib/config/util/custom_padding.dart
@@ -1,4 +1,7 @@
 class CustomPadding {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  CustomPadding._();
+
   static const double smallest = 3;
   static const double mini = 8;
   static const double small = 14;

--- a/lib/config/util/height_margin.dart
+++ b/lib/config/util/height_margin.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/cupertino.dart';
 
 class HeightMargin {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  HeightMargin._();
+
   static const SizedBox mini = SizedBox(height: 2);
   static const SizedBox small = SizedBox(height: 8);
   static const SizedBox normal = SizedBox(height: 16);

--- a/lib/config/util/width_margin.dart
+++ b/lib/config/util/width_margin.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 
 class WidthMargin {
+  /// プライベートコンストラクタで外部からのインスタンス化を防止
+  WidthMargin._();
+
   static const SizedBox mini = SizedBox(width: 4);
   static const SizedBox small = SizedBox(width: 8);
   static const SizedBox normal = SizedBox(width: 16);

--- a/lib/feature/auth/controller/auth_controller.dart
+++ b/lib/feature/auth/controller/auth_controller.dart
@@ -11,14 +11,17 @@ class AuthController extends _$AuthController {
     return;
   }
 
+  /// githubアカウントでアカウントを作成 or サインイン
   Future<UserCredential?> signInWithGitHub() async {
     return await ref.read(authRepoProvider.notifier).signInWithGitHub();
   }
 
+  /// サインアウト
   Future<void> signOut() async {
     await ref.read(authRepoProvider.notifier).signOut();
   }
 
+  /// アカウントを削除
   Future<void> delete() async {
     await ref.read(authRepoProvider.notifier).delete();
   }

--- a/lib/feature/auth/repo/auth_repo.dart
+++ b/lib/feature/auth/repo/auth_repo.dart
@@ -11,7 +11,7 @@ class AuthRepo extends _$AuthRepo {
     return ref.read(firebaseAuthInstanceProvider).currentUser;
   }
 
-  // githubの認証
+  /// githubの認証
   Future<UserCredential?> signInWithGitHub() async {
     try {
       final GithubAuthProvider githubProvider = GithubAuthProvider();
@@ -28,18 +28,18 @@ class AuthRepo extends _$AuthRepo {
     }
   }
 
-  //ログアウト処理
+  /// ログアウト処理
   Future<void> signOut() async {
     await ref.read(firebaseAuthInstanceProvider).signOut();
     state = ref.read(firebaseAuthInstanceProvider).currentUser;
   }
 
-  // アカウント削除処理
+  /// アカウント削除処理
   Future<void> delete() async {
     await ref.read(authRepoProvider.notifier).delete();
   }
 
-  // Authの状態を監視する
+  /// Authの状態を監視する
   Stream<User?> authStateChange() {
     return ref.watch(firebaseAuthInstanceProvider).authStateChanges().map((
       User? currentUser,

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -52,6 +52,7 @@ class AuthLoginPage extends ConsumerWidget {
             children: [
               Column(
                 children: [
+                  // ようこそテキスト
                   Text(
                     localizations.welcome,
                     style: const TextStyle(
@@ -60,6 +61,7 @@ class AuthLoginPage extends ConsumerWidget {
                     ),
                   ),
                   HeightMargin.large,
+                  // 説明テキスト
                   Text(
                     localizations.appDescription,
                     style: const TextStyle(fontSize: CustomFontSize.medium),
@@ -68,15 +70,12 @@ class AuthLoginPage extends ConsumerWidget {
               ),
               SizedBox(
                 height: 60,
+                // 言語切り替えボタン
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    backgroundColor:
-                        Theme.of(context).colorScheme.primaryContainer,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),
-                    elevation: 1,
-                    shadowColor: Theme.of(context).colorScheme.tertiary,
                   ),
                   onPressed: () async {
                     showLoadingDialog(localizations.connecting);
@@ -126,6 +125,7 @@ class AuthLoginPage extends ConsumerWidget {
               value: credentail.credential?.accessToken ?? '',
             );
       } else {
+        // アクセストークンが取得できなかった場合
         showToast(localizations.tokenFailure);
       }
     } else {

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:search_repositories/common_widget/dialog/loading_dialog.dart';
 import 'package:search_repositories/common_widget/loading_widget.dart';
 import 'package:search_repositories/common_widget/toast/show_toast.dart';
 import 'package:search_repositories/config/key/secure_storage_key.dart';
@@ -77,8 +78,9 @@ class AuthLoginPage extends ConsumerWidget {
                     shadowColor: Theme.of(context).colorScheme.tertiary,
                   ),
                   onPressed: () async {
-                    //TODO: ローディングダイアログの表示
+                    showLoadingDialog('接続中...');
                     await _signInWithGitHub(ref, localizations);
+                    hideLoadingDialog();
                   },
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -78,9 +78,7 @@ class AuthLoginPage extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () async {
-                    showLoadingDialog(localizations.connecting);
                     await _signInWithGitHub(ref, localizations);
-                    hideLoadingDialog();
                   },
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
@@ -112,11 +110,11 @@ class AuthLoginPage extends ConsumerWidget {
     WidgetRef ref,
     AppLocalizations localizations,
   ) async {
+    showLoadingDialog(localizations.connecting);
     final UserCredential? credentail =
         await ref.read(authControllerProvider.notifier).signInWithGitHub();
     if (credentail != null) {
       // 認証成功
-      showToast(localizations.connectionSuccess);
       if (((credentail.credential?.accessToken) != null)) {
         await ref
             .read(secureStorageControllerProvider.notifier)
@@ -124,12 +122,16 @@ class AuthLoginPage extends ConsumerWidget {
               key: SecureStorageKey.githubAccessToken,
               value: credentail.credential?.accessToken ?? '',
             );
+        hideLoadingDialog();
+        showToast(localizations.connectionSuccess);
       } else {
         // アクセストークンが取得できなかった場合
+        hideLoadingDialog();
         showToast(localizations.tokenFailure);
       }
     } else {
       // 認証失敗
+      hideLoadingDialog();
       showToast(localizations.connectionFailure);
     }
   }

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -78,7 +78,7 @@ class AuthLoginPage extends ConsumerWidget {
                     shadowColor: Theme.of(context).colorScheme.tertiary,
                   ),
                   onPressed: () async {
-                    showLoadingDialog('接続中...');
+                    showLoadingDialog(localizations.connecting);
                     await _signInWithGitHub(ref, localizations);
                     hideLoadingDialog();
                   },

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -1,8 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:search_repositories/common_widget/loading_widget.dart';
 import 'package:search_repositories/common_widget/toast/show_toast.dart';
 import 'package:search_repositories/config/key/secure_storage_key.dart';
+import 'package:search_repositories/config/locale/controller/locale_provider.dart';
 import 'package:search_repositories/config/util/color_style.dart';
 import 'package:search_repositories/config/util/custom_font_size.dart';
 import 'package:search_repositories/config/util/custom_padding.dart';
@@ -10,10 +13,6 @@ import 'package:search_repositories/config/util/height_margin.dart';
 import 'package:search_repositories/config/util/width_margin.dart';
 import 'package:search_repositories/feature/auth/controller/auth_controller.dart';
 import 'package:search_repositories/feature/auth/controller/secure_storage_controller.dart';
-import 'package:search_repositories/common_widget/loading_widget.dart';
-import 'package:search_repositories/config/locale/controller/locale_provider.dart';
-
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 part './part/language_toggle_button.dart';
 

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -7,6 +7,7 @@ import 'package:search_repositories/common_widget/loading_widget.dart';
 import 'package:search_repositories/common_widget/toast/show_toast.dart';
 import 'package:search_repositories/config/key/secure_storage_key.dart';
 import 'package:search_repositories/config/locale/controller/locale_provider.dart';
+import 'package:search_repositories/config/util/app_assets.dart';
 import 'package:search_repositories/config/util/color_style.dart';
 import 'package:search_repositories/config/util/custom_font_size.dart';
 import 'package:search_repositories/config/util/custom_padding.dart';
@@ -86,8 +87,7 @@ class AuthLoginPage extends ConsumerWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Image.asset(
-                        // TODO: クラスで管理
-                        'assets/github_icon/github-mark.png',
+                        AppAssets.githubIcon,
                         width: 34,
                         height: 34,
                         color: Theme.of(context).colorScheme.primary,

--- a/lib/feature/auth/view/auth_login_page.dart
+++ b/lib/feature/auth/view/auth_login_page.dart
@@ -78,11 +78,13 @@ class AuthLoginPage extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () async {
+                    // GitHubでアカウント作成 or サインイン
                     await _signInWithGitHub(ref, localizations);
                   },
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
+                      // GitHubアイコン
                       Image.asset(
                         AppAssets.githubIcon,
                         width: 34,
@@ -90,6 +92,7 @@ class AuthLoginPage extends ConsumerWidget {
                         color: Theme.of(context).colorScheme.primary,
                       ),
                       WidthMargin.normal,
+                      // 「GitHubでサインイン」テキスト
                       Text(
                         localizations.signInGitHub,
                         style: const TextStyle(fontSize: CustomFontSize.medium),

--- a/lib/feature/auth/view/part/language_toggle_button.dart
+++ b/lib/feature/auth/view/part/language_toggle_button.dart
@@ -21,6 +21,7 @@ class LanguageToggleButton extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: CustomPadding.normal),
         child: Row(
           children: [
+            // 言語テキスト
             Text(
               localizations!.languageSettings,
               style: const TextStyle(
@@ -29,6 +30,7 @@ class LanguageToggleButton extends ConsumerWidget {
               ),
             ),
             WidthMargin.small,
+            // 地球儀アイコン
             const Icon(Icons.language, color: ColorStyle.blueAccent),
           ],
         ),
@@ -71,7 +73,10 @@ class LanguageToggleButton extends ConsumerWidget {
           if (currentLocale.languageCode == languageCode)
             const Icon(Icons.check, size: 18),
           WidthMargin.small,
-          Text(languageName),
+          Text(
+            languageName,
+            style: const TextStyle(fontSize: CustomFontSize.small),
+          ),
         ],
       ),
     );

--- a/lib/feature/github/controller/github_controller.dart
+++ b/lib/feature/github/controller/github_controller.dart
@@ -1,28 +1,66 @@
+import 'dart:developer';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_repositories/config/key/secure_storage_key.dart';
 import 'package:search_repositories/feature/auth/controller/secure_storage_controller.dart';
 import 'package:search_repositories/feature/github/model/api_response.dart';
 import 'package:search_repositories/feature/github/repo/search_github_repo.dart';
 
+/*
+GitHub Repositoryの検索をするためのController
+*/
 Future<List<ApiResponse>> searchGitHubController(
   String keyword,
   WidgetRef ref,
 ) async {
-  const String defaultQuery = 'stars:>10000';
-  final String query = keyword.trim().isEmpty ? defaultQuery : keyword;
-  final Uri url = Uri.parse(
-    'https://api.github.com/search/repositories?q=$query&sort=stars&order=desc',
-  );
+  try {
+    // 検索キーワードが空の場合は、デフォルトで検索する値を設定
+    final String queryKeyword = keyword.isEmpty ? 'stars:>10000' : keyword;
 
-  // TODO: 文字が変わるたびに検索していたら瞬間的に何回もapi叩くから制限かかっちゃう
-  final String? accessToken = await ref
-      .read(secureStorageControllerProvider.notifier)
-      .getValue(key: SecureStorageKey.githubAccessToken);
+    // GitHubのAPIのURL設定
+    final String urlString =
+        'https://api.github.com/search/repositories?q=$queryKeyword&sort=stars&order=desc';
+    final Uri url = Uri.parse(urlString);
 
-  final Map<String, String> headers = {
-    'Accept': 'application/vnd.github.v3+json',
-    'Authorization': 'Bearer ${accessToken ?? ''}',
-  };
+    // アクセストークンの取得
+    final String? accessToken = await _getGitHubAccessToken(ref);
+    if (accessToken == null || accessToken.isEmpty) {
+      log('GitHub access token is not set or empty');
+      throw Exception('GitHubへのアクセストークンが見つかりません。再度ログインしてください。');
+    }
 
-  return searchGitHubRepo(keyword, url, headers);
+    // ヘッダーの設定
+    final Map<String, String> headers = {
+      'Authorization': 'token $accessToken',
+      'Accept': 'application/vnd.github.v3+json',
+    };
+
+    // リポジトリの検索実行
+    return await searchGitHubRepo(queryKeyword, url, headers);
+  } catch (e) {
+    log('Error in searchGitHubController: $e');
+    throw Exception('GitHub APIへのアクセスに失敗しました: ${e.toString()}');
+  }
+}
+
+/*
+GitHubのアクセストークンを取得する
+*/
+Future<String?> _getGitHubAccessToken(WidgetRef ref) async {
+  try {
+    final String? accessToken = await ref
+        .read(secureStorageControllerProvider.notifier)
+        .getValue(key: SecureStorageKey.githubAccessToken);
+
+    // アクセストークンが取得できなかった場合はログに記録
+    if (accessToken == null || accessToken.isEmpty) {
+      log('Failed to retrieve GitHub access token from secure storage');
+    } else {
+      log('Successfully retrieved GitHub access token');
+    }
+
+    return accessToken;
+  } catch (e) {
+    log('Error retrieving GitHub access token: $e');
+    return null;
+  }
 }

--- a/lib/feature/github/repo/search_github_repo.dart
+++ b/lib/feature/github/repo/search_github_repo.dart
@@ -30,7 +30,6 @@ Future<List<ApiResponse>> searchGitHubRepo(
       );
     }
   } catch (e) {
-    print('GitHub API error: $e');
     throw Exception('Failed to fetch repositories: $e');
   }
 }

--- a/lib/feature/github/repo/search_github_repo.dart
+++ b/lib/feature/github/repo/search_github_repo.dart
@@ -2,20 +2,35 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:search_repositories/feature/github/model/api_response.dart';
 
+/// GitHubレポジトリを検索する関数
+/// 401エラーが発生した場合は1回だけリトライする
 Future<List<ApiResponse>> searchGitHubRepo(
   String keyword,
   Uri url,
-  Map<String, String> headers,
-) async {
-  final response = await http.get(url, headers: headers);
-  if (response.statusCode == 200) {
-    final data = json.decode(response.body) as Map<String, dynamic>;
-    final items = data['items'] as List<dynamic>;
+  Map<String, String> headers, {
+  bool isRetry = false,
+}) async {
+  try {
+    final response = await http.get(url, headers: headers);
 
-    return items
-        .map((item) => ApiResponse.fromJson(item as Map<String, dynamic>))
-        .toList();
-  } else {
-    throw Exception('GitHub API error: ${response.statusCode}');
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      final items = data['items'] as List<dynamic>;
+
+      return items
+          .map((item) => ApiResponse.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } else if (response.statusCode == 401 && !isRetry) {
+      // 認証エラーで、まだリトライしていない場合は、少し待ってからリトライ
+      await Future.delayed(const Duration(milliseconds: 500));
+      return searchGitHubRepo(keyword, url, headers, isRetry: true);
+    } else {
+      throw Exception(
+        'GitHub API error: ${response.statusCode} - ${response.body}',
+      );
+    }
+  } catch (e) {
+    print('GitHub API error: $e');
+    throw Exception('Failed to fetch repositories: $e');
   }
 }

--- a/lib/feature/github/view/repository_list_page.dart
+++ b/lib/feature/github/view/repository_list_page.dart
@@ -34,6 +34,10 @@ class RepositoryListPage extends HookConsumerWidget {
     final TextEditingController searchTextController =
         useTextEditingController();
     final ValueNotifier<String> keyword = useState<String>('');
+    final ValueNotifier<Future<List<ApiResponse>>?> futureRepositories =
+        useState<Future<List<ApiResponse>>?>(null);
+    final ValueNotifier<bool> isLoading = useState<bool>(true);
+    final ValueNotifier<String?> errorMessage = useState<String?>(null);
 
     /*
     多言語対応
@@ -43,6 +47,21 @@ class RepositoryListPage extends HookConsumerWidget {
     if (localizations == null) {
       return const Scaffold(body: Center(child: LoadingWidget()));
     }
+
+    // 初回ロード時とキーワード変更時にデータを取得
+    useEffect(() {
+      // 少し遅延してからデータを取得（認証が完了するまでの時間を確保）
+      Future.delayed(const Duration(milliseconds: 300), () {
+        _fetchRepositories(
+          keyword.value,
+          ref,
+          futureRepositories,
+          isLoading,
+          errorMessage,
+        );
+      });
+      return null;
+    }, [keyword.value]);
 
     return UnFocusKeyBoardWidget(
       child: Scaffold(
@@ -75,36 +94,125 @@ class RepositoryListPage extends HookConsumerWidget {
           ),
         ),
         body: SafeArea(
-          child: FutureBuilder(
-            future: searchGitHubController(keyword.value, ref),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const LoadingWidget();
-              } else if (snapshot.hasError) {
-                return ErrorTextWidget(text: snapshot.error.toString());
-              } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
-                return const ErrorTextWidget(text: 'データが見つかりませんでした');
-              }
-
-              final List<ApiResponse> repositories = snapshot.data!;
-              return ListView.separated(
-                separatorBuilder:
-                    (context, index) => const Padding(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: CustomPadding.normal,
-                      ),
-                      child: Divider(),
+          child:
+              isLoading.value
+                  ? const Center(child: LoadingWidget())
+                  : errorMessage.value != null
+                  ? Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        ErrorTextWidget(text: errorMessage.value!),
+                        const SizedBox(height: 16),
+                        ElevatedButton(
+                          onPressed: () {
+                            isLoading.value = true;
+                            errorMessage.value = null;
+                            _fetchRepositories(
+                              keyword.value,
+                              ref,
+                              futureRepositories,
+                              isLoading,
+                              errorMessage,
+                            );
+                          },
+                          child: const Text('再読み込み'),
+                        ),
+                      ],
                     ),
-                itemCount: repositories.length,
-                itemBuilder: (context, index) {
-                  final repo = repositories[index];
-                  return RepositoryListTile(repo: repo);
-                },
-              );
-            },
-          ),
+                  )
+                  : FutureBuilder(
+                    future: futureRepositories.value,
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const LoadingWidget();
+                      } else if (snapshot.hasError) {
+                        return Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              ErrorTextWidget(text: snapshot.error.toString()),
+                              const SizedBox(height: 16),
+                              ElevatedButton(
+                                onPressed: () {
+                                  isLoading.value = true;
+                                  errorMessage.value = null;
+                                  _fetchRepositories(
+                                    keyword.value,
+                                    ref,
+                                    futureRepositories,
+                                    isLoading,
+                                    errorMessage,
+                                  );
+                                },
+                                child: const Text('再読み込み'),
+                              ),
+                            ],
+                          ),
+                        );
+                      } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+                        return const ErrorTextWidget(text: 'データが見つかりませんでした');
+                      }
+
+                      final List<ApiResponse> repositories = snapshot.data!;
+                      return ListView.separated(
+                        separatorBuilder:
+                            (context, index) => const Padding(
+                              padding: EdgeInsets.symmetric(
+                                horizontal: CustomPadding.normal,
+                              ),
+                              child: Divider(),
+                            ),
+                        itemCount: repositories.length,
+                        itemBuilder: (context, index) {
+                          final repo = repositories[index];
+                          return RepositoryListTile(repo: repo);
+                        },
+                      );
+                    },
+                  ),
         ),
       ),
     );
+  }
+
+  // リポジトリ取得メソッド
+  void _fetchRepositories(
+    String keyword,
+    WidgetRef ref,
+    ValueNotifier<Future<List<ApiResponse>>?> futureRepositories,
+    ValueNotifier<bool> isLoading,
+    ValueNotifier<String?> errorMessage,
+  ) {
+    try {
+      futureRepositories.value = searchGitHubController(keyword, ref);
+      futureRepositories.value!
+          .then((_) {
+            isLoading.value = false;
+          })
+          .catchError((error) {
+            isLoading.value = false;
+            errorMessage.value = "データの取得に失敗しました: ${error.toString()}";
+
+            // 1秒後に自動的に再試行する
+            Future.delayed(const Duration(seconds: 1), () {
+              if (errorMessage.value != null) {
+                // まだエラー状態なら
+                isLoading.value = true;
+                errorMessage.value = null;
+                _fetchRepositories(
+                  keyword,
+                  ref,
+                  futureRepositories,
+                  isLoading,
+                  errorMessage,
+                );
+              }
+            });
+          });
+    } catch (e) {
+      isLoading.value = false;
+      errorMessage.value = "予期せぬエラーが発生しました: ${e.toString()}";
+    }
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,6 +27,7 @@
   "connectionSuccess": "Connection successful",
   "tokenFailure": "Failed to get token",
   "connectionFailure": "Connection failed",
+  "connecting": "Connecting...",
   
   "confirmTitle": "Confirm",
   "yes": "Yes",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -27,6 +27,7 @@
   "connectionSuccess": "接続成功",
   "tokenFailure": "トークン取得に失敗",
   "connectionFailure": "接続に失敗",
+  "connecting": "接続中...",
   
   "confirmTitle": "確認",
   "yes": "はい",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -27,6 +27,7 @@
   "connectionSuccess": "연결 성공",
   "tokenFailure": "토큰 가져오기 실패",
   "connectionFailure": "연결 실패",
+  "connecting": "연결 중...",
   
   "confirmTitle": "확인",
   "yes": "예",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -27,6 +27,7 @@
   "connectionSuccess": "连接成功",
   "tokenFailure": "获取令牌失败",
   "connectionFailure": "连接失败",
+  "connecting": "连接中...",
   
   "confirmTitle": "确认",
   "yes": "是",


### PR DESCRIPTION
# このPRの対応範囲
【追加6点】
1. lintsのルールにimport文をアルファベット順にするルールを追加
2. githubの認証中にローディングを回すように修正
3. githubアイコンの画像パスをクラスで管理するように変更
4. 定数を監視するクラスをプライベートに変更
5. 認証に成功して一覧画面に遷移した時に、リポジトリ一覧がエラーになってしまう問題を解決
6. コードに適切なコメントを追記、修正
