### PR TITLE
ハンバーガーメニュータイル内のexpandedを削除

### DIFF
--- a/lib/feature/github/view/part/repository_list/drawer_widget.dart
+++ b/lib/feature/github/view/part/repository_list/drawer_widget.dart
@@ -26,22 +26,20 @@ class DrawerWidget extends ConsumerWidget {
           ),
           // ダークモードの切り替え
           ListTile(
-            title: Expanded(
-              child: Row(
-                children: [
-                  Text(
-                    (ref.watch(themeControllerProvider) == ThemeMode.dark)
-                        ? localizations.darkMode
-                        : localizations.lightMode,
-                  ),
-                  WidthMargin.small,
-                  Icon(
-                    (ref.watch(themeControllerProvider) == ThemeMode.dark)
-                        ? Icons.dark_mode
-                        : Icons.light_mode,
-                  ),
-                ],
-              ),
+            title: Row(
+              children: [
+                Text(
+                  (ref.watch(themeControllerProvider) == ThemeMode.dark)
+                      ? localizations.darkMode
+                      : localizations.lightMode,
+                ),
+                WidthMargin.small,
+                Icon(
+                  (ref.watch(themeControllerProvider) == ThemeMode.dark)
+                      ? Icons.dark_mode
+                      : Icons.light_mode,
+                ),
+              ],
             ),
             trailing: Switch(
               value: ref.watch(themeControllerProvider) == ThemeMode.dark,


### PR DESCRIPTION
# このPRの対応範囲
【追加1点】
1. ハンバーガーメニュー内のダークモード変更タイルでexpandedを使用していたので削除

関連issue #24 
