### PR TITLE
アカウント削除処理の修正

### DIFF
--- a/lib/config/routing/app_router.dart
+++ b/lib/config/routing/app_router.dart
@@ -69,6 +69,15 @@ GoRouter appRouter(ref) {
           return const NoTransitionPage(child: AuthLoginPage());
         },
       ),
+      // 外部認証からリダイレクト
+      GoRoute(
+        path: AppRoute.link.path,
+        name: AppRoute.link.name,
+        redirect: (_, __) {
+          // リダイレクトされた場合は、認証ページにリダイレクト
+          return AppRoute.auth.path;
+        },
+      ),
       GoRoute(
         path: AppRoute.repositoryList.path,
         name: AppRoute.repositoryList.name,

--- a/lib/config/routing/router_enum.dart
+++ b/lib/config/routing/router_enum.dart
@@ -1,8 +1,10 @@
-enum AppRoute { auth, repositoryList, repositoryDetail }
+enum AppRoute { link, auth, repositoryList, repositoryDetail }
 
 extension AppRouteExtention on AppRoute {
   String get path {
     switch (this) {
+      case AppRoute.link:
+        return '/link';
       case AppRoute.auth:
         return '/auth';
       case AppRoute.repositoryList:

--- a/lib/feature/auth/controller/auth_controller.dart
+++ b/lib/feature/auth/controller/auth_controller.dart
@@ -20,6 +20,7 @@ class AuthController extends _$AuthController {
 
   /// サインアウト
   Future<void> signOut() async {
+    // 先にトークンを削除
     await ref
         .read(secureStorageControllerProvider.notifier)
         .deleteValue(key: SecureStorageKey.githubAccessToken);
@@ -28,6 +29,7 @@ class AuthController extends _$AuthController {
 
   /// アカウントを削除
   Future<void> delete() async {
+    // 先にトークンを削除
     await ref
         .read(secureStorageControllerProvider.notifier)
         .deleteValue(key: SecureStorageKey.githubAccessToken);

--- a/lib/feature/auth/controller/auth_controller.dart
+++ b/lib/feature/auth/controller/auth_controller.dart
@@ -20,17 +20,17 @@ class AuthController extends _$AuthController {
 
   /// サインアウト
   Future<void> signOut() async {
-    await ref.read(authRepoProvider.notifier).signOut();
     await ref
         .read(secureStorageControllerProvider.notifier)
         .deleteValue(key: SecureStorageKey.githubAccessToken);
+    await ref.read(authRepoProvider.notifier).signOut();
   }
 
   /// アカウントを削除
   Future<void> delete() async {
-    await ref.read(authRepoProvider.notifier).delete();
     await ref
         .read(secureStorageControllerProvider.notifier)
         .deleteValue(key: SecureStorageKey.githubAccessToken);
+    await ref.read(authRepoProvider.notifier).delete();
   }
 }

--- a/lib/feature/auth/repo/auth_repo.dart
+++ b/lib/feature/auth/repo/auth_repo.dart
@@ -21,7 +21,8 @@ class AuthRepo extends _$AuthRepo {
     try {
       final GithubAuthProvider githubProvider = GithubAuthProvider();
 
-      final UserCredential credentail = await FirebaseAuth.instance
+      final UserCredential credentail = await ref
+          .read(firebaseAuthInstanceProvider)
           .signInWithProvider(githubProvider);
       // 認証成功
       if (((credentail.credential?.accessToken) != null)) {
@@ -57,6 +58,16 @@ class AuthRepo extends _$AuthRepo {
 
   /// アカウント削除処理
   Future<void> delete() async {
-    await ref.read(authRepoProvider.notifier).delete();
+    // アカウント削除のために再度サインイン
+    final GithubAuthProvider githubProvider = GithubAuthProvider();
+    print('開始');
+    await ref
+        .read(firebaseAuthInstanceProvider)
+        .signInWithProvider(githubProvider);
+    print('サインイン');
+    await ref.read(firebaseAuthInstanceProvider).currentUser?.delete();
+    print('アカウント削除');
+    state = ref.read(firebaseAuthInstanceProvider).currentUser;
+    print('state: $state');
   }
 }

--- a/lib/feature/auth/repo/auth_repo.dart
+++ b/lib/feature/auth/repo/auth_repo.dart
@@ -60,14 +60,12 @@ class AuthRepo extends _$AuthRepo {
   Future<void> delete() async {
     // アカウント削除のために再度サインイン
     final GithubAuthProvider githubProvider = GithubAuthProvider();
-    print('開始');
     await ref
         .read(firebaseAuthInstanceProvider)
         .signInWithProvider(githubProvider);
-    print('サインイン');
+    // 削除を実行
     await ref.read(firebaseAuthInstanceProvider).currentUser?.delete();
-    print('アカウント削除');
+    // 状態を更新
     state = ref.read(firebaseAuthInstanceProvider).currentUser;
-    print('state: $state');
   }
 }


### PR DESCRIPTION
# このPRの対応範囲
【修正前の問題点】
アカウント削除処理が正常に作成されていなかったので、押してもローディングがずっと回るだけだった。

【変更2点】
1. 削除処理を実装
2. サインインで外部サイトに行ってアプリにリダイレクトで戻ってくる時のgoRouterを正しく設定し、エラー画面にならないように対応
