### PR TITLE
多言語設定の修正

### DIFF
--- a/lib/config/locale/language_config.dart
+++ b/lib/config/locale/language_config.dart
@@ -7,7 +7,7 @@ class LanguageConfig {
     'ja': '日本語',
     'en': 'English',
     'ko': '한국어',
-    'zh': '中文',
+    'zh': '简体中文',
   };
 
   /// アプリで対応している言語のロケールリスト

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,7 +8,7 @@
   "logout": "Logout",
   "deleteAccount": "Delete Account",
   "logoutConfirmation": "Are you sure you want to log out?",
-  "deleteConfirmation": "Are you sure you want to delete your account?",
+  "deleteConfirmation": "Are you sure you want to delete your account?\nOnce you press 「Yes」, the process will begin and cannot be undone.",
   "loggingOut": "Logging out...",
   "loggedOut": "Logged out",
   "deleting": "Deleting...",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -8,7 +8,7 @@
   "logout": "ログアウト",
   "deleteAccount": "アカウント削除",
   "logoutConfirmation": "ログアウトしますか？",
-  "deleteConfirmation": "本当にアカウントを削除しますか？",
+  "deleteConfirmation": "本当にアカウントを削除してもよろしいですか？\n「はい」を押すと削除処理が開始され、元に戻すことはできません。",
   "loggingOut": "ログアウト中...",
   "loggedOut": "ログアウトしました",
   "deleting": "削除中...",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -8,7 +8,7 @@
   "logout": "로그아웃",
   "deleteAccount": "계정 삭제",
   "logoutConfirmation": "로그아웃 하시겠습니까?",
-  "deleteConfirmation": "정말로 계정을 삭제하시겠습니까?",
+  "deleteConfirmation": "정말로 계정을 삭제하시겠습니까?\n「예」를 누르면 삭제가 시작되며, 되돌릴 수 없습니다.",
   "loggingOut": "로그아웃 중...",
   "loggedOut": "로그아웃 되었습니다",
   "deleting": "삭제 중...",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -8,7 +8,7 @@
   "logout": "登出",
   "deleteAccount": "删除账户",
   "logoutConfirmation": "确定要登出吗？",
-  "deleteConfirmation": "确定要删除账户吗？",
+  "deleteConfirmation": "您确定要删除账户吗？\n点击「是」后将开始删除，操作无法撤销。",
   "loggingOut": "正在登出...",
   "loggedOut": "已登出",
   "deleting": "正在删除...",


### PR DESCRIPTION
# このPRの対応範囲
【追加2点】
1. 確認ダイアログの説明文の内容を具体化して多言語対応に反映
2. 中国語の選択肢のテキストを修正
