### PR TITLE
launch_urlでエラーが発生したら多言語対応のエラーメッセージを表示する

### DIFF
--- a/lib/feature/github/view/repository_detail_page.dart
+++ b/lib/feature/github/view/repository_detail_page.dart
@@ -38,7 +38,7 @@ class RepositoryDetailPage extends ConsumerWidget {
           IconButton(
             onPressed: () {
               // レポジトリへ遷移
-              launchInExternalBrowser(repository.url);
+              launchInExternalBrowser(repository.url, context);
             },
             icon: const Icon(Icons.open_in_new),
           ),

--- a/lib/function/launch_url.dart
+++ b/lib/function/launch_url.dart
@@ -1,14 +1,24 @@
+import 'package:search_repositories/common_widget/dialog/loading_dialog.dart';
+import 'package:search_repositories/common_widget/loading_widget.dart';
+import 'package:search_repositories/common_widget/toast/show_toast.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// 引数で受け取ったURLを外部ブラウザで開く
-Future<void> launchInExternalBrowser(String url) async {
+Future<void> launchInExternalBrowser(String url, BuildContext context) async {
   final uri = Uri.parse(url);
+  final AppLocalizations localizations = AppLocalizations.of(context)!;
+  showLoadingDialog(localizations.preparing);
   if (await canLaunchUrl(uri)) {
     await launchUrl(
       uri,
       mode: LaunchMode.externalApplication, // 外部ブラウザで開く
     );
+    hideLoadingDialog();
   } else {
-    throw 'Could not launch $url';
+    hideLoadingDialog();
+    showToast('${localizations.couldNotLaunchUrl}: $url');
+    throw '${localizations.couldNotLaunchUrl}: $url';
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,5 +38,7 @@
   "rateLimitError": "Rate limit exceeded. Please try again later.",
   "notFoundError": "Not found.",
   "serverError": "Server error. Please try again later.",
-  "unexpectedError": "An unexpected error occurred."
+  "unexpectedError": "An unexpected error occurred.",
+  "couldNotLaunchUrl": "Could not open URL",
+  "preparing": "Preparing..."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -38,5 +38,7 @@
   "rateLimitError": "アクセス制限がかかりました。時間をおいてお試しください。",
   "notFoundError": "見つかりませんでした。",
   "serverError": "サーバーに問題があります。しばらく経ってから再度お試しください。",
-  "unexpectedError": "予期せぬエラーが発生しました。"
+  "unexpectedError": "予期せぬエラーが発生しました。",
+  "couldNotLaunchUrl": "URLを開けませんでした",
+  "preparing": "準備中..."
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -38,5 +38,7 @@
   "rateLimitError": "접근 제한이 발생했습니다. 잠시 후 다시 시도하세요.",
   "notFoundError": "찾을 수 없습니다.",
   "serverError": "서버에 문제가 있습니다. 잠시 후 다시 시도하세요.",
-  "unexpectedError": "예기치 않은 오류가 발생했습니다."
+  "unexpectedError": "예기치 않은 오류가 발생했습니다.",
+  "couldNotLaunchUrl": "URL을 열 수 없습니다",
+  "preparing": "준비 중..."
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -38,5 +38,7 @@
   "rateLimitError": "访问受限。请稍后再试。",
   "notFoundError": "未找到。",
   "serverError": "服务器出现问题。请稍后再试。",
-  "unexpectedError": "发生意外错误。"
+  "unexpectedError": "发生意外错误。",
+  "couldNotLaunchUrl": "无法打开URL",
+  "preparing": "准备中..."
 }


### PR DESCRIPTION
# このPRの対応範囲
【追加2点】
1. launch中の状態をローディング、トーストで表示
2. エラーの場合は多言語対応のエラーメッセージを表示
